### PR TITLE
Interpret missing kCBMsgArgResult as success.

### DIFF
--- a/darwin/msg.go
+++ b/darwin/msg.go
@@ -35,7 +35,7 @@ func (m msg) deviceUUID() xpc.UUID       { return xpc.Dict(m).MustGetUUID("kCBMs
 func (m msg) ignoreResponse() int        { return xpc.Dict(m).MustGetInt("kCBMsgArgIgnoreResponse") }
 func (m msg) offset() int                { return xpc.Dict(m).MustGetInt("kCBMsgArgOffset") }
 func (m msg) isNotification() int        { return xpc.Dict(m).GetInt("kCBMsgArgIsNotification", 0) }
-func (m msg) result() int                { return xpc.Dict(m).MustGetInt("kCBMsgArgResult") }
+func (m msg) result() int                { return xpc.Dict(m).GetInt("kCBMsgArgResult", 0) }
 func (m msg) state() int                 { return xpc.Dict(m).MustGetInt("kCBMsgArgState") }
 func (m msg) rssi() int                  { return xpc.Dict(m).MustGetInt("kCBMsgArgData") }
 func (m msg) transactionID() int         { return xpc.Dict(m).MustGetInt("kCBMsgArgTransactionID") }


### PR DESCRIPTION
This PR addresses a panic that occurs in older versions of MacOS (tested with 10.11.5).  The panic text is below:

```
panic: interface conversion: interface {} is nil, not int64

goroutine 1 [running]:
github.com/raff/goble/xpc.Dict.MustGetInt(0xc420242330, 0x46dab64, 0xf, 0x0)
        /Users/ccollins/go/src/github.com/raff/goble/xpc/xpc.go:56 +0x18d
github.com/go-ble/ble/darwin.msg.result(0xc420242330, 0x5)
        /Users/ccollins/go/src/github.com/go-ble/ble/darwin/msg.go:39 +0x40
github.com/go-ble/ble/darwin.msg.err(0xc420242330, 0x46, 0xc4201da630)
        /Users/ccollins/go/src/github.com/go-ble/ble/darwin/msg.go:62 +0x8c
github.com/go-ble/ble/darwin.(*Client).DiscoverDescriptors(0xc4201f04b0, 0x0, 0x0, 0x0, 0xc4200da4d0, 0xc420226810, 0x2, 0x2, 0x0, 0x0)
        /Users/ccollins/go/src/github.com/go-ble/ble/darwin/client.go:153 +0x382
github.com/go-ble/ble/darwin.(*Client).DiscoverProfile(0xc4201f04b0, 0x46fc301, 0xc420200048, 0x0, 0x0)
        /Users/ccollins/go/src/github.com/go-ble/ble/darwin/client.go:58 +0x1ba
mynewt.apache.org/newtmgr/newtmgr/bll.(*BllSesn).txDiscoverProfile(0xc420200000, 0x0, 0x0, 0x0)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/bll/bll_sesn.go:106 +0x97
mynewt.apache.org/newtmgr/newtmgr/bll.(*BllSesn).discoverAll(0xc420200000, 0x0, 0x0)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/bll/bll_sesn.go:198 +0x74
mynewt.apache.org/newtmgr/newtmgr/bll.(*BllSesn).openOnce(0xc420200000, 0x0, 0xc4201e6180, 0x200)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/bll/bll_sesn.go:288 +0x139
mynewt.apache.org/newtmgr/newtmgr/bll.(*BllSesn).Open(0xc420200000, 0x49ecfa0, 0xc420200000)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/bll/bll_sesn.go:305 +0x4f
mynewt.apache.org/newtmgr/newtmgr/cli.GetSesn(0xc420062040, 0x3, 0xc420022000, 0xc420022070)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/cli/common.go:329 +0xc2
mynewt.apache.org/newtmgr/newtmgr/cli.echoRunCmd(0xc4201d6900, 0xc420088820, 0x1, 0x5)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/cli/echo.go:37 +0x49
mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra.(*Command).execute(0xc4201d6900, 0xc42012c380, 0x5, 0x8, 0xc4201d6900, 0xc42012c380)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra/command.go:654 +0x2a2
mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4200938c0, 0xc420135f08, 0xc420135ef8, 0xc420049a80)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra/command.go:729 +0x2fe
mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200938c0, 0x46fa1f0, 0xc420170240)
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/vendor/github.com/spf13/cobra/command.go:688 +0x2b
main.main()
        /Users/ccollins/go/src/mynewt.apache.org/newtmgr/newtmgr/newtmgr.go:102 +0xea
```

The problem occurs because, on this machine, the DiscoverDescriptors response lacks a `kCBMsgArgResult` field.  This missing field must have gotten fixed in a subsequent version of MacOS.  Here are the contents of the DiscoverDescriptors response:

```
map[kCBMsgArgCharacteristicHandle:17 kCBMsgArgDeviceUUID:3e8e65b72da94f70bbbe2d8f1a2524ee kCBMsgArgDescriptors:[]]
```

The fix is to treat a response that lacks the `kCBMsgArgResult` field as indicating success.  That is, pretend `kCBMsgArgResult` is 0.

I don't know if this is the proper fix for this problem.  Alternative solutions are:

* Apply this logic only while handling a DiscoverDescriptors response, rather than all responses.
* Only apply this logic for a set of MacOS versions.
* Never check for errors in the DiscoverDescriptors handler (this is what currantlabs does).

I opted for this solution because it is the simplest, and I feel that assuming success in this case is more desirable than panicking.