### PR TITLE
linux - Don't log "can't accept" error on close.

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -2,6 +2,7 @@ package linux
 
 import (
 	"context"
+	"io"
 	"log"
 
 	"github.com/go-ble/ble"
@@ -50,7 +51,11 @@ func loop(dev *hci.HCI, s *gatt.Server, mtu int) {
 	for {
 		l2c, err := dev.Accept()
 		if err != nil {
-			log.Printf("can't accept: %s", err)
+			// An EOF error indicates that the HCI socket was closed during
+			// the read.  Don't report this as an error.
+			if err != io.EOF {
+				log.Printf("can't accept: %s", err)
+			}
 			return
 		}
 


### PR DESCRIPTION
This is a hack which silences an extraneous log message.  The message gets reported due to an apparent race condition involving the `sktLoop()` function in `linux/hci/hci.go`.  This function implements a socket-read loop that only returns on error.  It is called as a Goroutine, and typically continues to run until the process terminates.

If client code closes the owning `Device` at an inopportune time (presumably during the socket read), the `Read()` call returns an `io.EOF` error, which causes `NewDevice()` to log the following message:

```
    can't accept: skt: EOF
```

Since the API permits the user to close the device at any time, this error message is extraneous.

This commit simply inhibits the logging of the error message in case of EOF.  This is not a long-term solution, but it does fix the visible issue.