### PR TITLE
Fix deadlock on writing connection to master chan

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -442,7 +442,11 @@ func (h *HCI) handleLEConnectionComplete(b []byte) error {
 	h.muConns.Unlock()
 	if e.Role() == roleMaster {
 		if e.Status() == 0x00 {
-			h.chMasterConn <- c
+			select {
+			case h.chMasterConn <- c:
+			default:
+				go c.Close()
+			}
 			return nil
 		}
 		if ErrCommand(e.Status()) == ErrConnID {


### PR DESCRIPTION
When a context with a timeout is used on [connect](https://github.com/go-ble/ble/blob/master/gatt.go#L126) it can happen that the message for connection is read from the Socket after the timout and cancelation of the connection establishment.

If the [Dial func](https://github.com/go-ble/ble/blob/master/linux/hci/gap.go#L217) is not trying to read from the `h.chMasterConn` anymore the write to `h.chMasterConn` is blocking the [sktLoop](https://github.com/go-ble/ble/blob/master/linux/hci/hci.go#L266-L288)

This change removes the deadlock when nobody is reading from the `h.chMasterConn` and closes the connection in a new goroutine.