### PR TITLE
darwin: Fix deadlock from multiple evtPeripheralConnected events

### DIFF
--- a/darwin/conn.go
+++ b/darwin/conn.go
@@ -43,6 +43,8 @@ type conn struct {
 	notifiers map[uint16]ble.Notifier // central connection only
 
 	subs map[uint16]*sub
+
+	isConnected bool
 }
 
 func (c *conn) Context() context.Context {

--- a/darwin/device.go
+++ b/darwin/device.go
@@ -489,10 +489,15 @@ func (d *Device) HandleXpcEvent(event xpc.Dict, err error) {
 		d.conn(args).unsubscribed(d.chars[args.attributeID()])
 
 	case evtPeripheralConnected:
-		d.chConn <- d.conn(args)
+		c := d.conn(args)
+		if !c.isConnected {
+			c.isConnected = true
+			d.chConn <- c
+		}
 
 	case evtPeripheralDisconnected:
 		c := d.conn(args)
+		c.isConnected = false
 		select {
 		case c.rspc <- m:
 			// Canceled by local central synchronously


### PR DESCRIPTION
Fixes: #24 