### PR TITLE
Add Conn method to Client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,4 +66,7 @@ type Client interface {
 
 	// Disconnected returns a receiving channel, which is closed when the client disconnects.
 	Disconnected() <-chan struct{}
+
+	// Conn returns the client's current connection.
+	Conn() Conn
 }

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -320,6 +320,11 @@ func (cln *Client) Disconnected() <-chan struct{} {
 	return cln.conn.Disconnected()
 }
 
+// Conn returns the client's current connection.
+func (cln *Client) Conn() ble.Conn {
+	return cln.conn
+}
+
 type sub struct {
 	fn   ble.NotificationHandler
 	char *ble.Characteristic

--- a/darwin/conn.go
+++ b/darwin/conn.go
@@ -77,7 +77,9 @@ func (c *conn) TxMTU() int {
 }
 
 func (c *conn) SetTxMTU(mtu int) {
+	c.Lock()
 	c.txMTU = mtu
+	c.Unlock()
 }
 
 func (c *conn) Read(b []byte) (int, error) {

--- a/darwin/conn.go
+++ b/darwin/conn.go
@@ -9,10 +9,10 @@ import (
 	"github.com/raff/goble/xpc"
 )
 
-func newConn(d *Device, a ble.Addr) *conn {
+func newConn(d *Device, a ble.Addr, rxMTU int) *conn {
 	return &conn{
 		dev:   d,
-		rxMTU: 23,
+		rxMTU: rxMTU,
 		txMTU: 23,
 		addr:  a,
 		done:  make(chan struct{}),

--- a/darwin/device.go
+++ b/darwin/device.go
@@ -546,7 +546,7 @@ func (d *Device) conn(m msg) *conn {
 	d.connLock.Lock()
 	c, ok := d.conns[a.String()]
 	if !ok {
-		c = newConn(d, a)
+		c = newConn(d, a, m.attMTU())
 		d.conns[a.String()] = c
 	}
 	d.connLock.Unlock()

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -371,6 +371,11 @@ func (p *Client) Disconnected() <-chan struct{} {
 	return p.conn.Disconnected()
 }
 
+// Conn returns the client's current connection.
+func (p *Client) Conn() ble.Conn {
+	return p.l2c
+}
+
 // HandleNotification ...
 func (p *Client) HandleNotification(req []byte) {
 	p.Lock()

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -373,7 +373,7 @@ func (p *Client) Disconnected() <-chan struct{} {
 
 // Conn returns the client's current connection.
 func (p *Client) Conn() ble.Conn {
-	return p.l2c
+	return p.conn
 }
 
 // HandleNotification ...


### PR DESCRIPTION
This pull request allows the user to access connection information such as the current RX/TX MTU sizes. It also fixes a race detector warning.