### PR TITLE
linux/att: fix duplicated switch case error

### DIFF
--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -466,7 +466,7 @@ func (c *Client) ExecuteWrite(flags uint8) error {
 	switch {
 	case rsp[0] == ErrorResponseCode && len(rsp) == 5:
 		return ble.ATTError(rsp[4])
-	case rsp[0] == ErrorResponseCode && len(rsp) == 5:
+	case rsp[0] == ErrorResponseCode && len(rsp) != 5:
 		fallthrough
 	case rsp[0] != rsp.AttributeOpcode():
 		return ErrInvalidResponse


### PR DESCRIPTION
The `rsp[0] == ErrorResponseCode && len(rsp) == 5` case was duplicated.
Surrounding code uses `rsp[0] == ErrorResponseCode && len(rsp) != 5` (note "not equal")
for the second case, so probably this is probably what we want there as well.