### PR TITLE
linux.hci: fix stop advertise on new connection

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -501,7 +501,7 @@ func (h *HCI) handleLEConnectionComplete(b []byte) error {
 		// So we also re-enable the advertising when a connection disconnected
 		h.params.RLock()
 		if h.params.advEnable.AdvertisingEnable == 1 {
-			go h.Send(&h.params.advEnable, nil)
+			go h.Send(&cmd.LESetAdvertiseEnable{0}, nil)
 		}
 		h.params.RUnlock()
 	}


### PR DESCRIPTION
this line was a no-op, thus allowing multiple simultaneous connections, since it was just re-sending 1 (h.params.advEnable equals 1 from line above)