### PR TITLE
linux.hci: do not exit sktLoop on handlePacket error

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -310,8 +310,8 @@ func (h *HCI) sktLoop() {
 			if strings.HasPrefix(err.Error(), "unsupported vendor packet:") {
 				_ = logger.Error("skt: %v", err)
 			} else {
-				h.err = fmt.Errorf("skt: %v", err)
-				return
+				log.Printf("skt: %v", err)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
this allows more robustness in case there is an error on connection. Maybe this addresses some of the currently open issues regarding unstable service (#33, maybe #34)

Not sure this is the better way to implement this, but it is giving me excellent results on stability, especially when clients are being aggressive, so I'm leaving this here