### PR TITLE
Corrected ioctl on mips (#52)

### DIFF
--- a/linux/hci/socket/constants_linux.go
+++ b/linux/hci/socket/constants_linux.go
@@ -1,0 +1,12 @@
+// +build !mips
+
+package socket
+
+const (
+	directionWrite = 1
+	directionRead  = 2
+
+	directionShift = 30
+	sizeShift      = 16
+	typeShift      = 8
+)

--- a/linux/hci/socket/constants_linux_mips.go
+++ b/linux/hci/socket/constants_linux_mips.go
@@ -1,0 +1,10 @@
+package socket
+
+const (
+	directionWrite = 4
+	directionRead  = 2
+
+	directionShift = 29
+	sizeShift      = 16
+	typeShift      = 8
+)

--- a/linux/hci/socket/socket.go
+++ b/linux/hci/socket/socket.go
@@ -13,11 +13,11 @@ import (
 )
 
 func ioR(t, nr, size uintptr) uintptr {
-	return (2 << 30) | (t << 8) | nr | (size << 16)
+	return (directionRead << directionShift) | (t << typeShift) | nr | (size << sizeShift)
 }
 
 func ioW(t, nr, size uintptr) uintptr {
-	return (1 << 30) | (t << 8) | nr | (size << 16)
+	return (directionWrite << directionShift) | (t << typeShift) | nr | (size << sizeShift)
 }
 
 func ioctl(fd, op, arg uintptr) error {


### PR DESCRIPTION
Splits ioR and ioW related constants to a separate file and uses architecture build flags to determine which set to use.

Fixes `file descriptor in bad state` error from #52.

