### PR TITLE
Make the *darwin.Device implement the ble.DeviceOption interface

### DIFF
--- a/darwin/option.go
+++ b/darwin/option.go
@@ -5,7 +5,18 @@ import (
 	"time"
 
 	"github.com/go-ble/ble/linux/hci/cmd"
+	"github.com/go-ble/ble/linux/hci/evt"
 )
+
+// SetConnectedHandler sets handler to be called when new connection is established.
+func (d *Device) SetConnectedHandler(f func(evt.LEConnectionComplete)) error {
+	return errors.New("Not supported")
+}
+
+// SetDisconnectedHandler sets handler to be called on disconnect.
+func (d *Device) SetDisconnectedHandler(f func(evt.DisconnectionComplete)) error {
+	return errors.New("Not supported")
+}
 
 // SetPeripheralRole configures the device to perform Peripheral tasks.
 func (d *Device) SetPeripheralRole() error {


### PR DESCRIPTION
- [X] Add `SetConnectedHandler` and `SetDisconnectedHandler` to `*darwin.Device`

Related to issue: https://github.com/go-ble/ble/issues/59

This change only allows the code to compile, not to actually work.