### PR TITLE
Don't try to handle canceled connections

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -473,6 +473,10 @@ func (h *HCI) handleCommandStatus(b []byte) error {
 
 func (h *HCI) handleLEConnectionComplete(b []byte) error {
 	e := evt.LEConnectionComplete(b)
+	if e.Role() == roleMaster && ErrCommand(e.Status()) == ErrConnID {
+		// The connection was canceled successfully.
+		return nil
+	}
 	c := newConn(h, e)
 	h.muConns.Lock()
 	h.conns[e.ConnectionHandle()] = c
@@ -484,10 +488,6 @@ func (h *HCI) handleLEConnectionComplete(b []byte) error {
 			default:
 				go c.Close()
 			}
-			return nil
-		}
-		if ErrCommand(e.Status()) == ErrConnID {
-			// The connection was canceled successfully.
 			return nil
 		}
 		return nil


### PR DESCRIPTION
Currently the check to see if a connection was canceled happens *after*
newConn() is called, leaking a goroutine waiting to receive on chInPkt.
Move the check up.

Closes #77.