### PR TITLE
Race condition in Send fixed

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -227,7 +227,10 @@ func (h *HCI) init() error {
 
 // Send ...
 func (h *HCI) Send(c Command, r CommandRP) error {
+	// Only allow one send after another to prevent race condition
+	h.Mutex.Lock()
 	b, err := h.send(c)
+	h.Mutex.Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because ```send(c Command) ([]byte, error)``` depends on channels and Send is invocated by goroutines there is a race condition. With the use of the mutex its guaranteed that the correct ```handleCommandComplete``` is used.

