### PR TITLE
Use correct device ID when opening HCI device

### DIFF
--- a/linux/hci/socket/socket.go
+++ b/linux/hci/socket/socket.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package socket
@@ -77,7 +78,7 @@ func NewSocket(id int) (*Socket, error) {
 	}
 	var msg string
 	for id := 0; id < int(req.devNum); id++ {
-		s, err := open(fd, id)
+		s, err := open(fd, int(req.devRequest[id].id))
 		if err == nil {
 			return s, nil
 		}


### PR DESCRIPTION
This fixes an issue where there is only one HCI device available, but it's called hci1, not hci0.