### PR TITLE
linux: avoid hanging in Advertise*() and Scan() in case of HCI error

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -109,7 +109,11 @@ func (d *Device) Advertise(ctx context.Context, adv ble.Advertisement) error {
 	if err := d.HCI.AdvertiseAdv(adv); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 
@@ -122,7 +126,11 @@ func (d *Device) AdvertiseNameAndServices(ctx context.Context, name string, uuid
 	if err := d.HCI.AdvertiseNameAndServices(name, uuids...); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 }
@@ -132,7 +140,11 @@ func (d *Device) AdvertiseMfgData(ctx context.Context, id uint16, b []byte) erro
 	if err := d.HCI.AdvertiseMfgData(id, b); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 }
@@ -142,7 +154,11 @@ func (d *Device) AdvertiseServiceData16(ctx context.Context, id uint16, b []byte
 	if err := d.HCI.AdvertiseServiceData16(id, b); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 }
@@ -152,7 +168,11 @@ func (d *Device) AdvertiseIBeaconData(ctx context.Context, b []byte) error {
 	if err := d.HCI.AdvertiseIBeaconData(b); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 }
@@ -162,7 +182,11 @@ func (d *Device) AdvertiseIBeacon(ctx context.Context, u ble.UUID, major, minor 
 	if err := d.HCI.AdvertiseIBeacon(u, major, minor, pwr); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopAdvertising()
 	return ctx.Err()
 }
@@ -175,7 +199,11 @@ func (d *Device) Scan(ctx context.Context, allowDup bool, h ble.AdvHandler) erro
 	if err := d.HCI.Scan(allowDup); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	}
 	d.HCI.StopScanning()
 	return ctx.Err()
 }

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -169,6 +169,11 @@ func (h *HCI) Close() error {
 	return h.close(nil)
 }
 
+// Done ...
+func (h *HCI) Done() <-chan bool {
+	return h.done
+}
+
 // Error ...
 func (h *HCI) Error() error {
 	return h.err


### PR DESCRIPTION
Correctly propagate errors to avoid unrecoverable hanging in case of unexpected HCI error, such as disconnection of USB adapter.

Previously the internal goroutine with the `Accept()` loop would terminate but `Scan()` and all variants of `Advertise()` would just hang in such a situation, with no practical way for the surrounding application to detect or recover the error.