### PR TITLE
ReadLongCharacteristic() uses RxMtu()

### DIFF
--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -231,7 +231,7 @@ func (p *Client) ReadLongCharacteristic(c *ble.Characteristic) ([]byte, error) {
 	}
 	buffer = append(buffer, read...)
 
-	for len(read) >= p.conn.TxMTU()-1 {
+	for len(read) >= p.conn.RxMTU()-1 {
 		if read, err = p.ac.ReadBlob(c.ValueHandle, uint16(len(buffer))); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I think ReadLongCharacteristic() should use RxMTU() to decide if the read length hints to a follow up transfer:
https://github.com/go-ble/ble/blob/8c5522f543335a80e18fc70e704b104cf3fcc606/linux/gatt/client.go#L234-L239

Testcase:
Call client.ExchangeMTU(200) to limit the MTU on our side.
Then trigger a long read. You will notice that the date length returned matches this 200.