### PR TITLE
Extended advertising scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-.*.swp
-.tags
-.tags1
-
-/examples/bin/*
-vendor
 .idea
+.uuid
+*DS_Store

--- a/device.go
+++ b/device.go
@@ -1,6 +1,8 @@
 package ble
 
-import "context"
+import (
+	"context"
+)
 
 // Device ...
 type Device interface {
@@ -39,6 +41,9 @@ type Device interface {
 
 	// Scan starts scanning. Duplicated advertisements will be filtered out if allowDup is set to false.
 	Scan(ctx context.Context, allowDup bool, h AdvHandler) error
+
+	// ExtendedScan starts scanning. Duplicated advertisements will be filtered out if allowDup is set to false.
+	ExtendedScan(ctx context.Context, allowDup bool, h ExtendedAdvHandler) error
 
 	// Dial ...
 	Dial(ctx context.Context, a Addr) (Client, error)

--- a/examples/basic/extended_scanner/main.go
+++ b/examples/basic/extended_scanner/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/go-ble/ble/examples/lib/dev"
+	"log"
+	"time"
+
+	"github.com/go-ble/ble"
+	"github.com/pkg/errors"
+)
+
+var (
+	device = flag.String("device", "default", "implementation of ble")
+	du     = flag.Duration("du", 5*time.Second, "scanning duration")
+	dup    = flag.Bool("dup", true, "allow duplicate reported")
+)
+
+func main() {
+	flag.Parse()
+
+	d, err := dev.BLE5Device()
+	if err != nil {
+		log.Fatalf("can't new device : %s", err)
+	}
+	ble.SetDefaultDevice(d)
+	// ExtendedScan for specified durantion, or until interrupted by user.
+	fmt.Printf("ExtendedScaning for %s...\n", *du)
+	ctx := ble.WithSigHandler(context.WithTimeout(context.Background(), *du))
+	chkErr(ble.ExtendedScan(ctx, *dup, advHandler, nil))
+}
+
+func advHandler(a ble.ExtendedAdvertisement) {
+	if a.Connectable() {
+		fmt.Printf("[%s] C %3d:", a.Addr(), a.RSSI())
+	} else {
+		fmt.Printf("[%s] N %3d:", a.Addr(), a.RSSI())
+	}
+	comma := ""
+	if len(a.LocalName()) > 0 {
+		fmt.Printf(" Name: %s", a.LocalName())
+		comma = ","
+	}
+	if len(a.Services()) > 0 {
+		fmt.Printf("%s Svcs: %v", comma, a.Services())
+		comma = ","
+	}
+	if len(a.ManufacturerData()) > 0 {
+		fmt.Printf("%s MD: %X", comma, a.ManufacturerData())
+	}
+	fmt.Printf("\n")
+}
+
+func chkErr(err error) {
+	switch errors.Cause(err) {
+	case nil:
+	case context.DeadlineExceeded:
+		fmt.Printf("done\n")
+	case context.Canceled:
+		fmt.Printf("canceled\n")
+	default:
+		log.Fatalf(err.Error())
+	}
+}

--- a/examples/basic/extended_scanner/main.go
+++ b/examples/basic/extended_scanner/main.go
@@ -21,7 +21,7 @@ var (
 func main() {
 	flag.Parse()
 
-	d, err := dev.BLE5Device()
+	d, err := dev.AdvertisingExtensionsDevice()
 	if err != nil {
 		log.Fatalf("can't new device : %s", err)
 	}

--- a/examples/blesh/lnx.go
+++ b/examples/blesh/lnx.go
@@ -31,6 +31,20 @@ func updateLinuxParam(d *linux.Device) error {
 		return errors.Wrap(err, "can't set scan param")
 	}
 
+	if err := d.HCI.Send(&cmd.LESetExtendedScanParameters{
+		OwnAddressType:       0x00,   // 0x00: public, 0x01: random
+		ScanningFilterPolicy: 0x00,   // 0x00: accept all, 0x01: ignore non-white-listed
+		ScanningPHYs:         0x01,   // 0x01: Scan on the LE 1M PHY, 0x04: Scan on the LE Coded PHY
+		ScanType1M:           0x01,   // 0x00: passive scan, 0x01: active scan
+		ScanInterval1M:       0x0004, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanWindow1M:         0x0004, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanTypeCoded:        0x01,   // 0x00: passive scan, 0x01: active scan (for Coded PHY)
+		ScanIntervalCoded:    0x0004, // N * 0.625 msec, scan interval for Coded PHY
+		ScanWindowCoded:      0x0004, // N * 0.625 msec, scan window for Coded PHY
+	}, nil); err != nil {
+		return errors.Wrap(err, "can't set scan param")
+	}
+
 	if err := d.HCI.Option(ble.OptConnParams(
 		cmd.LECreateConnection{
 			LEScanInterval:        0x0004,    // 0x0004 - 0x4000; N * 0.625 msec

--- a/examples/lib/dev/default_linux.go
+++ b/examples/lib/dev/default_linux.go
@@ -9,3 +9,8 @@ import (
 func DefaultDevice(opts ...ble.Option) (d ble.Device, err error) {
 	return linux.NewDevice(opts...)
 }
+
+// BLE5Device ...
+func BLE5Device(opts ...ble.Option) (d ble.Device, err error) {
+	return linux.NewBLE5Device(opts...)
+}

--- a/examples/lib/dev/default_linux.go
+++ b/examples/lib/dev/default_linux.go
@@ -10,7 +10,7 @@ func DefaultDevice(opts ...ble.Option) (d ble.Device, err error) {
 	return linux.NewDevice(opts...)
 }
 
-// BLE5Device ...
-func BLE5Device(opts ...ble.Option) (d ble.Device, err error) {
-	return linux.NewBLE5Device(opts...)
+// AdvertisingExtensionsDevice ...
+func AdvertisingExtensionsDevice(opts ...ble.Option) (d ble.Device, err error) {
+	return linux.NewAdvertisingExtensionsDevice(opts...)
 }

--- a/examples/lib/dev/dev.go
+++ b/examples/lib/dev/dev.go
@@ -8,3 +8,8 @@ import (
 func NewDevice(impl string, opts ...ble.Option) (d ble.Device, err error) {
 	return DefaultDevice(opts...)
 }
+
+// NewBLE5Device ...
+func NewBLE5Device(impl string, opts ...ble.Option) (d ble.Device, err error) {
+	return BLE5Device(opts...)
+}

--- a/examples/lib/dev/dev.go
+++ b/examples/lib/dev/dev.go
@@ -9,7 +9,7 @@ func NewDevice(impl string, opts ...ble.Option) (d ble.Device, err error) {
 	return DefaultDevice(opts...)
 }
 
-// NewBLE5Device ...
-func NewBLE5Device(impl string, opts ...ble.Option) (d ble.Device, err error) {
-	return BLE5Device(opts...)
+// NewAdvertisingExtensionsDevice ...
+func NewAdvertisingExtensionsDevice(impl string, opts ...ble.Option) (d ble.Device, err error) {
+	return AdvertisingExtensionsDevice(opts...)
 }

--- a/extended_adv.go
+++ b/extended_adv.go
@@ -1,0 +1,22 @@
+package ble
+
+// ExtendedAdvHandler handles extended advertisements.
+type ExtendedAdvHandler func(a ExtendedAdvertisement)
+
+// ExtendedAdvFilter returns true if the extended advertisement matches specified condition.
+type ExtendedAdvFilter func(a ExtendedAdvertisement) bool
+
+// ExtendedAdvertisement ...
+type ExtendedAdvertisement interface {
+	LocalName() string
+	ManufacturerData() []byte
+	ServiceData() []ServiceData
+	Services() []UUID
+	OverflowService() []UUID
+	TxPowerLevel() int
+	Connectable() bool
+	SolicitedService() []UUID
+
+	RSSI() int
+	Addr() Addr
+}

--- a/gatt.go
+++ b/gatt.go
@@ -100,6 +100,26 @@ func Scan(ctx context.Context, allowDup bool, h AdvHandler, f AdvFilter) error {
 	return defaultDevice.Scan(ctx, allowDup, h2)
 }
 
+// ExtendedScan starts scanning. Duplicated advertisements will be filtered out if allowDup is set to false.
+func ExtendedScan(ctx context.Context, allowDup bool, h ExtendedAdvHandler, f AdvFilter) error {
+	if defaultDevice == nil {
+		return ErrDefaultDevice
+	}
+	defer untrap(trap(ctx))
+
+	if f == nil {
+		return defaultDevice.ExtendedScan(ctx, allowDup, h)
+	}
+
+	h2 := func(a ExtendedAdvertisement) {
+		if f(a) {
+			h(a)
+		}
+	}
+
+	return defaultDevice.ExtendedScan(ctx, allowDup, h2)
+}
+
 // Find ...
 func Find(ctx context.Context, allowDup bool, f AdvFilter) ([]Advertisement, error) {
 	if defaultDevice == nil {

--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -2,7 +2,6 @@ package adv
 
 import (
 	"encoding/binary"
-
 	"github.com/go-ble/ble"
 )
 

--- a/linux/device.go
+++ b/linux/device.go
@@ -50,18 +50,18 @@ func NewDeviceWithNameAndHandler(name string, handler ble.NotifyHandler, opts ..
 	return &Device{HCI: dev, Server: srv}, nil
 }
 
-// NewBLE5Device returns the default HCI device.
-func NewBLE5Device(opts ...ble.Option) (*Device, error) {
-	return NewBLE5DeviceWithName("Gopher", opts...)
+// NewAdvertisingExtensionsDevice returns the default HCI device.
+func NewAdvertisingExtensionsDevice(opts ...ble.Option) (*Device, error) {
+	return NewAdvertisingExtensionsDeviceWithName("Gopher", opts...)
 }
 
-// NewBLE5DeviceWithName returns the default HCI device.
-func NewBLE5DeviceWithName(name string, opts ...ble.Option) (*Device, error) {
-	return NewBLE5DeviceWithNameAndHandler(name, nil, opts...)
+// NewAdvertisingExtensionsDeviceWithName returns the default HCI device.
+func NewAdvertisingExtensionsDeviceWithName(name string, opts ...ble.Option) (*Device, error) {
+	return NewAdvertisingExtensionsDeviceWithNameAndHandler(name, nil, opts...)
 }
 
-func NewBLE5DeviceWithNameAndHandler(name string, handler ble.NotifyHandler, opts ...ble.Option) (*Device, error) {
-	dev, err := hci.NewHCIForBLE5(opts...)
+func NewAdvertisingExtensionsDeviceWithNameAndHandler(name string, handler ble.NotifyHandler, opts ...ble.Option) (*Device, error) {
+	dev, err := hci.NewHCIForAdvertisingExtensions(opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't create hci")
 	}

--- a/linux/hci/cmd/cmd_gen.go
+++ b/linux/hci/cmd/cmd_gen.go
@@ -1560,3 +1560,140 @@ type LERemoteConnectionParameterRequestNegativeReplyRP struct {
 func (c *LERemoteConnectionParameterRequestNegativeReplyRP) Unmarshal(b []byte) error {
 	return unmarshal(c, b)
 }
+
+// LESetExtendedScanParameters implements LE Set Extended Scan Parameters (0x08|0x0041) [Vol 4, Part E, 7.8.64]
+type LESetExtendedScanParameters struct {
+	OwnAddressType       uint8
+	ScanningFilterPolicy uint8
+	ScanningPHYs         uint8
+	ScanType1M           uint8
+	ScanInterval1M       uint16
+	ScanWindow1M         uint16
+	ScanTypeCoded        uint8
+	ScanIntervalCoded    uint16
+	ScanWindowCoded      uint16
+}
+
+func (c *LESetExtendedScanParameters) String() string {
+	return "LE Set Extended Scan Parameters (0x08|0x0041)"
+}
+
+// OpCode returns the opcode of the command.
+func (c *LESetExtendedScanParameters) OpCode() int { return 0x08<<10 | 0x0041 }
+
+// Len returns the length of the command.
+func (c *LESetExtendedScanParameters) Len() int { return 13 }
+
+// Marshal serializes the command parameters into binary form.
+func (c *LESetExtendedScanParameters) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+// LESetExtendedScanParametersRP returns the return parameter of LE Set Extended Scan Parameters
+type LESetExtendedScanParametersRP struct {
+	Status uint8
+}
+
+// Unmarshal de-serializes the binary data and stores the result in the receiver.
+func (c *LESetExtendedScanParametersRP) Unmarshal(b []byte) error {
+	return unmarshal(c, b)
+}
+
+// LESetExtendedScanEnable implements LE Set Extended Scan Enable (0x08|0x0042) [Vol 4, Part E, 7.8.65]
+type LESetExtendedScanEnable struct {
+	Enable           uint8
+	FilterDuplicates uint8
+	Duration         uint16
+	Period           uint16
+}
+
+func (c *LESetExtendedScanEnable) String() string {
+	return "LE Set Extended Scan Enable (0x08|0x0042)"
+}
+
+// OpCode returns the opcode of the command.
+func (c *LESetExtendedScanEnable) OpCode() int { return 0x08<<10 | 0x0042 }
+
+// Len returns the length of the command.
+func (c *LESetExtendedScanEnable) Len() int { return 6 }
+
+// Marshal serializes the command parameters into binary form.
+func (c *LESetExtendedScanEnable) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+// LESetExtendedScanEnableRP returns the return parameter of LE Set Extended Scan Enable
+type LESetExtendedScanEnableRP struct {
+	Status uint8
+}
+
+// Unmarshal de-serializes the binary data and stores the result in the receiver.
+func (c *LESetExtendedScanEnableRP) Unmarshal(b []byte) error {
+	return unmarshal(c, b)
+}
+
+// LESetDefaultPHY implements LE Set Default PHY (0x08|0x0031) [Vol 4, Part E, 7.8.48]
+type LESetDefaultPHY struct {
+	AllPHYs uint8
+	TXPHYs  uint8
+	RXPHYs  uint8
+}
+
+func (c *LESetDefaultPHY) String() string {
+	return "LE Set Default PHY (0x08|0x0031)"
+}
+
+// OpCode returns the opcode of the command.
+func (c *LESetDefaultPHY) OpCode() int { return 0x08<<10 | 0x0031 }
+
+// Len returns the length of the command.
+func (c *LESetDefaultPHY) Len() int { return 3 }
+
+// Marshal serializes the command parameters into binary form.
+func (c *LESetDefaultPHY) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+// LESetExtendedAdvertisingParameters implements LE Set Extended Advertising Parameters (0x08|0x0036) [Vol 4, Part E, 7.8.53]
+type LESetExtendedAdvertisingParameters struct {
+	AdvertisingHandle             uint8
+	AdvertisingEventProperties    uint16
+	PrimaryAdvertisingIntervalMin [3]byte
+	PrimaryAdvertisingIntervalMax [3]byte
+	PrimaryAdvertisingChannelMap  uint8
+	OwnAddressType                uint8
+	PeerAddressType               uint8
+	PeerAddress                   [6]byte
+	AdvertisingFilterPolicy       uint8
+	AdvertisingTXPower            int8
+	PrimaryAdvertisingPHY         uint8
+	SecondaryAdvertisingMaxSkip   uint8
+	SecondaryAdvertisingPHY       uint8
+	AdvertisingSID                uint8
+	ScanRequestNotificationEnable uint8
+}
+
+func (c *LESetExtendedAdvertisingParameters) String() string {
+	return "LE Set Extended Advertising Parameters (0x08|0x0036)"
+}
+
+// OpCode returns the opcode of the command.
+func (c *LESetExtendedAdvertisingParameters) OpCode() int { return 0x08<<10 | 0x0036 }
+
+// Len returns the length of the command.
+func (c *LESetExtendedAdvertisingParameters) Len() int { return 25 }
+
+// Marshal serializes the command parameters into binary form.
+func (c *LESetExtendedAdvertisingParameters) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+// LESetExtendedAdvertisingParametersRP returns the return parameter of LE Set Extended Advertising Parameters
+type LESetExtendedAdvertisingParametersRP struct {
+	Status uint8
+}
+
+// Unmarshal de-serializes the binary data and stores the result in the receiver.
+func (c *LESetExtendedAdvertisingParametersRP) Unmarshal(b []byte) error {
+	return unmarshal(c, b)
+}

--- a/linux/hci/evt/evt.go
+++ b/linux/hci/evt/evt.go
@@ -1,6 +1,9 @@
 package evt
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 func (e CommandComplete) NumHCICommandPackets() uint8 { return e[0] }
 func (e CommandComplete) CommandOpcode() uint16       { return binary.LittleEndian.Uint16(e[1:]) }
@@ -53,3 +56,120 @@ func (e LEAdvertisingReport) RSSI(i int) int8 {
 	}
 	return int8(e[2+int(e.NumReports())*9+l+i])
 }
+
+// LEExtendedAdvertisingReport
+// 7.7.65.13 LE Extended Advertising Report
+// sample
+// [0] Subevent_Code
+// 0x0d
+// [1] Num_Reports
+// 0x01
+// [2,3] Num_Reports[0].Event_Type
+// 0x10 0x00
+// [4] Num_Reports[0].Address_Type
+// 0x01
+// [5,6,7,8,9,10] Num_Reports[0].Address
+// 0x87 0xe8 0xdb 0x97 0x13 0x75
+// [11] Num_Reports[0].Primary_PHY
+// 0x01
+// [12] Num_Reports[0].Secondary_PHY
+// 0x00
+// [13] Num_Reports[0].Advertising_SID
+// 0xff
+// [14] Num_Reports[0].TX_Power
+// 0x7f
+// [15] Num_Reports[0].RSSI
+// 0xde
+// [16,17] Num_Reports[0].Periodic_Advertising_Interval
+// 0x00 0x00
+// [18] Num_Reports[0].Direct_Address_Type
+// 0x00
+// [19,20,21,22,23,24] Num_Reports[0].Direct_Address_Type
+// 0x00 0x00 0x00 0x00 0x00 0x00
+// [25] Num_Reports[0].Data_Length
+// 0x1b
+// [26~x] Num_Reports[0].Data
+// 0x02  0x01  0x1a  0x17  0xff  0x4c  0x00  0x09  0x08  0x13  0x01  0xc0  0xa8  0x00  0x03  0x1b  0x58  0x16  0x08  0x00  0x4e  0x6e  0xe9  0x0b  0x53  0x48  0xdf
+
+const (
+	LEExtendedAdvertisingReportMetaDataLength  = 2
+	LEExtendedAdvertisingReportFixedDataLength = 24
+)
+
+type ExtendedAdvertisingReport struct {
+	SubeventCode uint8
+	NumReports   uint8
+	Reports      []ExtendedAdvertisingData
+}
+
+// AdvertisingReport represents an individual report within the LE Extended Advertising Report
+type ExtendedAdvertisingData struct {
+	EventType                   uint16
+	AddressType                 uint8
+	Address                     [6]byte
+	PrimaryPHY                  uint8
+	SecondaryPHY                uint8
+	AdvertisingSID              uint8
+	TXPower                     int8
+	RSSI                        int8
+	PeriodicAdvertisingInterval uint16
+	DirectAddressType           uint8
+	DirectAddress               [6]byte
+	DataLength                  uint8
+	Data                        []byte
+	ScanResp                    *ExtendedAdvertisingData
+}
+
+// ParseLEExtendedAdvertisingReport parses a byte array into a leExtendedAdvertisingReport structure
+func NewExtendedAdvertisingReport(data LEExtendedAdvertisingReport) (
+	*ExtendedAdvertisingReport,
+	error,
+) {
+	if len(data) < 2 {
+		return nil, fmt.Errorf("invalid data length")
+	}
+
+	report := &ExtendedAdvertisingReport{
+		SubeventCode: data[0],
+		NumReports:   data[1],
+	}
+
+	offset := 2
+	for i := 0; i < int(report.NumReports); i++ {
+		if offset+26 > len(data) {
+			return nil, fmt.Errorf("invalid data length for report %d", i)
+		}
+
+		// Parse individual report
+		r := ExtendedAdvertisingData{
+			EventType:                   uint16(data[offset]) | uint16(data[offset+1])<<8,
+			AddressType:                 data[offset+2],
+			PrimaryPHY:                  data[offset+11],
+			SecondaryPHY:                data[offset+12],
+			AdvertisingSID:              data[offset+13],
+			TXPower:                     int8(data[offset+14]),
+			RSSI:                        int8(data[offset+15]),
+			PeriodicAdvertisingInterval: uint16(data[offset+16]) | uint16(data[offset+17])<<8,
+			DirectAddressType:           data[offset+18],
+			DataLength:                  data[offset+25],
+		}
+		copy(r.Address[:], data[offset+3:offset+9])
+		copy(r.DirectAddress[:], data[offset+19:offset+25])
+
+		// Parse data field
+		dataEnd := offset + 26 + int(r.DataLength)
+		if dataEnd > len(data) {
+			return nil, fmt.Errorf("invalid data length for report %d data", i)
+		}
+		r.Data = data[offset+26 : dataEnd]
+
+		// Add to report list
+		report.Reports = append(report.Reports, r)
+		offset = dataEnd
+	}
+
+	return report, nil
+}
+
+func (e LEExtendedAdvertisingReport) SubeventCode() uint8 { return e[0] }
+func (e LEExtendedAdvertisingReport) NumReports() uint8   { return e[1] }

--- a/linux/hci/evt/evt_gen.go
+++ b/linux/hci/evt/evt_gen.go
@@ -225,3 +225,10 @@ type AuthenticatedPayloadTimeoutExpired []byte
 func (r AuthenticatedPayloadTimeoutExpired) ConnectionHandle() uint16 {
 	return binary.LittleEndian.Uint16(r[0:])
 }
+
+const LEExtendedAdvertisingReportCode = 0x3E
+
+const LEExtendedAdvertisingReportSubCode = 0x0D
+
+// LEExtendedAdvertisingReport implements LE Extended Advertising Report (0x3E:0x0D) [Vol 4, Part E, 7.7.65.13].
+type LEExtendedAdvertisingReport []byte

--- a/linux/hci/extended_adv.go
+++ b/linux/hci/extended_adv.go
@@ -189,7 +189,10 @@ func (a *ExtendedAdvertisingData) RSSI() int {
 
 // Addr returns the address of the remote peripheral.
 func (a *ExtendedAdvertisingData) Addr() ble.Addr {
-	addr := net.HardwareAddr(a.address)
+	addr := net.HardwareAddr([]byte{a.address[5], a.address[4], a.address[3], a.address[2], a.address[1], a.address[0]})
+	if a.addressType == 1 {
+		return RandomAddress{addr}
+	}
 	return addr
 }
 

--- a/linux/hci/extended_adv.go
+++ b/linux/hci/extended_adv.go
@@ -1,0 +1,209 @@
+package hci
+
+import (
+	"fmt"
+	"github.com/go-ble/ble"
+	"github.com/go-ble/ble/linux/adv"
+	"github.com/go-ble/ble/linux/hci/evt"
+	"net"
+)
+
+const (
+	evtTypExtendedAdvInd              = 0b00100011 // ADV_IND (Connectable and Scannable Undirected Advertising)
+	evtTypExtendedAdvDirectInd        = 0b00100101 // ADV_DIRECT_IND (Connectable Directed Advertising)
+	evtTypExtendedAdvScanInd          = 0b00100100 // ADV_SCAN_IND (Scannable Undirected Advertising)
+	evtTypExtendedAdvNonConnInd       = 0b00100000 // ADV_NONCONN_IND (Non-Connectable Undirected Advertising)
+	evtTypScanRspToExtendedAdvInd     = 0b00101111 // SCAN_RSP to ADV_IND (Scan Response to ADV_IND)
+	evtTypScanRspToExtendedAdvScanInd = 0b00101110 // SCAN_RSP to ADV_SCAN_IND (Scan Response to ADV_SCAN_IND)
+)
+
+type LEExtendedAdvertisingReport struct {
+	SubeventCode uint8
+	NumReports   uint8
+	Reports      []ExtendedAdvertisingData
+}
+
+// AdvertisingReport represents an individual report within the LE Extended Advertising Report
+type ExtendedAdvertisingData struct {
+	eventType                   uint16
+	addressType                 uint8
+	address                     []byte
+	primaryPHY                  uint8
+	secondaryPHY                uint8
+	advertisingSID              uint8
+	txPower                     int8
+	rssi                        int8
+	periodicAdvertisingInterval uint16
+	directAddressType           uint8
+	directAddress               []byte
+	dataLength                  uint8
+	data                        []byte
+	scanResp                    *ExtendedAdvertisingData
+
+	// cached packets.
+	p *adv.Packet
+}
+
+// sample
+
+// 0x0d Subevent_Code
+// 0x01 Num_Reports
+// 0x10  0x00 Event_Type
+// 0x01 Address_Type
+// 0xde  0xb4  0xc0  0xf9 0x90 0xfa Address
+// 0x01 Primary_PHY
+// 0x00 Secondary_PHY
+// 0xff Advertising_SID
+// 0x7f TX_Power
+// 0xdb RSSI
+// 0x00  0x00 Periodic_Advertising_Interval
+// 0x00  Direct_Address_Type
+// 0x00
+// 0x00  0x00  0x00  0x00  0x00  0x08 Direct_Address
+// 0x07
+// 0xff  0x4c  0x00  0x12  0x02  0x00  0x03
+
+const reportDataStaticLength = 24
+
+func newLEExtendedAdvertisingReport(data evt.LEExtendedAdvertisingReport) (
+	*LEExtendedAdvertisingReport,
+	error,
+) {
+	if len(data) < 2 {
+		return nil, fmt.Errorf("invalid data length")
+	}
+
+	report := &LEExtendedAdvertisingReport{
+		SubeventCode: data[0],
+		NumReports:   data[1],
+	}
+
+	offset := 2
+	for i := 0; i < int(report.NumReports); i++ {
+		if offset+reportDataStaticLength > len(data) {
+			return nil, fmt.Errorf("invalid data length %d for report %d", len(data), i)
+		}
+
+		// Parse individual report
+		r := ExtendedAdvertisingData{
+			eventType:                   uint16(data[offset]) | uint16(data[offset+1])<<8,
+			addressType:                 data[offset+2],
+			address:                     data[offset+3 : offset+9],
+			primaryPHY:                  data[offset+9],
+			secondaryPHY:                data[offset+10],
+			advertisingSID:              data[offset+11],
+			txPower:                     int8(data[offset+12]),
+			rssi:                        int8(data[offset+13]),
+			periodicAdvertisingInterval: uint16(data[offset+14]) | uint16(data[offset+15])<<8,
+			directAddressType:           data[offset+16],
+			directAddress:               data[offset+19 : offset+22],
+			dataLength:                  data[offset+23],
+			scanResp:                    &ExtendedAdvertisingData{},
+		}
+
+		// Parse data field
+		dataEnd := offset + reportDataStaticLength + int(r.dataLength)
+		if dataEnd > len(data) {
+			return nil, fmt.Errorf("invalid data length %d, dataEnd %d, for report %d data", len(data), dataEnd, i)
+		}
+		r.data = data[offset+reportDataStaticLength : dataEnd]
+
+		// Add to report list
+		report.Reports = append(report.Reports, r)
+		offset = dataEnd
+	}
+
+	return report, nil
+}
+
+// packets returns the combined extended advertising packet and scan response (if present).
+func (a *ExtendedAdvertisingData) packets() *adv.Packet {
+	if a.p != nil {
+		return a.p
+	}
+	b := a.data
+	if a.scanResp != nil {
+		b = append(b, a.scanResp.data...)
+	}
+	return adv.NewRawPacket(b)
+}
+
+func (a *ExtendedAdvertisingData) EventType() uint16 {
+	return a.eventType
+}
+
+func (a *ExtendedAdvertisingData) SetScanResp(d *ExtendedAdvertisingData) {
+	a.scanResp = d
+}
+
+// LocalName returns the LocalName of the remote peripheral.
+func (a *ExtendedAdvertisingData) LocalName() string {
+	if a.packets().LocalName() != "" {
+		return a.packets().LocalName()
+	}
+	if a.scanResp != nil && a.scanResp.LocalName() != "" {
+		return a.scanResp.LocalName()
+	}
+	return ""
+}
+
+// ManufacturerData returns the ManufacturerData of the advertisement.
+func (a *ExtendedAdvertisingData) ManufacturerData() []byte {
+	return a.packets().ManufacturerData()
+}
+
+// ServiceData returns the service data of the advertisement.
+func (a *ExtendedAdvertisingData) ServiceData() []ble.ServiceData {
+	return a.packets().ServiceData()
+}
+
+// Services returns the service UUIDs of the advertisement.
+func (a *ExtendedAdvertisingData) Services() []ble.UUID {
+	return a.packets().UUIDs()
+}
+
+// OverflowService returns the UUIDs of overflowed services.
+func (a *ExtendedAdvertisingData) OverflowService() []ble.UUID {
+	return a.packets().UUIDs()
+}
+
+// TxPowerLevel returns the tx power level of the remote peripheral.
+func (a *ExtendedAdvertisingData) TxPowerLevel() int {
+	pwr, _ := a.packets().TxPower()
+	return pwr
+}
+
+// SolicitedService returns UUIDs of solicited services.
+func (a *ExtendedAdvertisingData) SolicitedService() []ble.UUID {
+	return a.packets().ServiceSol()
+}
+
+// Connectable indicates whether the remote peripheral is connectable.
+func (a *ExtendedAdvertisingData) Connectable() bool {
+	return a.eventType == evtTypAdvDirectInd || a.eventType == evtTypAdvInd
+}
+
+func (a *ExtendedAdvertisingData) RSSI() int {
+	return int(a.rssi)
+}
+
+// Addr returns the address of the remote peripheral.
+func (a *ExtendedAdvertisingData) Addr() ble.Addr {
+	addr := net.HardwareAddr(a.address)
+	return addr
+}
+
+// Data returns the extended advertising data of the packet.
+// This is Linux specific.
+func (a *ExtendedAdvertisingData) Data() []byte {
+	return a.data
+}
+
+// ScanResponse returns the scan response of the extended packet, if present.
+// This is Linux specific.
+func (a *ExtendedAdvertisingData) ScanResponse() []byte {
+	if a.scanResp == nil {
+		return nil
+	}
+	return a.scanResp.Data()
+}

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -64,7 +64,7 @@ func NewHCI(opts ...ble.Option) (*HCI, error) {
 }
 
 // NewHCI returns a hci device.
-func NewHCIForBLE5(opts ...ble.Option) (*HCI, error) {
+func NewHCIForAdvertisingExtensions(opts ...ble.Option) (*HCI, error) {
 	h := &HCI{
 		id: -1,
 
@@ -83,7 +83,7 @@ func NewHCIForBLE5(opts ...ble.Option) (*HCI, error) {
 
 		done: make(chan bool),
 	}
-	h.params.initForBLE5()
+	h.params.initForAdvertisingExtensions()
 	if err := h.Option(opts...); err != nil {
 		return nil, errors.Wrap(err, "can't set options")
 	}
@@ -185,7 +185,7 @@ func (h *HCI) Init() error {
 
 	go h.sktLoop()
 	if h.params.extendedScanParams.ScanningPHYs != 0x00 {
-		if err := h.initForBLE5(); err != nil {
+		if err := h.initForAdvertisingExtensions(); err != nil {
 			return err
 		}
 	} else {
@@ -199,7 +199,7 @@ func (h *HCI) Init() error {
 	h.pool = NewPool(1+4+h.bufSize, h.bufCnt-1)
 
 	if h.params.extendedScanParams.ScanningPHYs != 0x00 {
-		log.Println("Enable BLE 5")
+		log.Println("Enable Advertising Extensions")
 		h.Send(&h.params.leSetDefaultPHY, nil)
 		h.Send(&h.params.extendedScanParams, nil)
 	} else {
@@ -280,7 +280,7 @@ func (h *HCI) init() error {
 	return h.err
 }
 
-func (h *HCI) initForBLE5() error {
+func (h *HCI) initForAdvertisingExtensions() error {
 	h.Send(&cmd.Reset{}, nil)
 
 	ReadBDADDRRP := cmd.ReadBDADDRRP{}

--- a/linux/hci/params.go
+++ b/linux/hci/params.go
@@ -9,15 +9,19 @@ import (
 type params struct {
 	sync.RWMutex
 
-	advEnable  cmd.LESetAdvertiseEnable
-	scanEnable cmd.LESetScanEnable
-	connCancel cmd.LECreateConnectionCancel
+	advEnable          cmd.LESetAdvertiseEnable
+	scanEnable         cmd.LESetScanEnable
+	extendedScanEnable cmd.LESetExtendedScanEnable
+	connCancel         cmd.LECreateConnectionCancel
 
-	advData    cmd.LESetAdvertisingData
-	scanResp   cmd.LESetScanResponseData
-	advParams  cmd.LESetAdvertisingParameters
-	scanParams cmd.LESetScanParameters
-	connParams cmd.LECreateConnection
+	leSetDefaultPHY cmd.LESetDefaultPHY
+
+	advData            cmd.LESetAdvertisingData
+	scanResp           cmd.LESetScanResponseData
+	advParams          cmd.LESetAdvertisingParameters
+	scanParams         cmd.LESetScanParameters
+	extendedScanParams cmd.LESetExtendedScanParameters
+	connParams         cmd.LECreateConnection
 }
 
 func (p *params) init() {
@@ -28,6 +32,7 @@ func (p *params) init() {
 		OwnAddressType:       0x00,   // 0x00: public, 0x01: random
 		ScanningFilterPolicy: 0x00,   // 0x00: accept all, 0x01: ignore non-white-listed.
 	}
+
 	p.advParams = cmd.LESetAdvertisingParameters{
 		AdvertisingIntervalMin:  0x0020,    // 0x0020 - 0x4000; N * 0.625 msec
 		AdvertisingIntervalMax:  0x0020,    // 0x0020 - 0x4000; N * 0.625 msec
@@ -38,6 +43,7 @@ func (p *params) init() {
 		AdvertisingChannelMap:   0x7,       // 0x07 0x01: ch37, 0x2: ch38, 0x4: ch39
 		AdvertisingFilterPolicy: 0x00,
 	}
+
 	p.connParams = cmd.LECreateConnection{
 		LEScanInterval:        0x0004,    // 0x0004 - 0x4000; N * 0.625 msec
 		LEScanWindow:          0x0004,    // 0x0004 - 0x4000; N * 0.625 msec
@@ -51,5 +57,37 @@ func (p *params) init() {
 		SupervisionTimeout:    0x0048,    // 0x000A - 0x0C80; N * 10 msec
 		MinimumCELength:       0x0000,    // 0x0000 - 0xFFFF; N * 0.625 msec
 		MaximumCELength:       0x0000,    // 0x0000 - 0xFFFF; N * 0.625 msec
+	}
+}
+
+func (p *params) initForBLE5() {
+	p.extendedScanParams = cmd.LESetExtendedScanParameters{
+		OwnAddressType:       0x00,   // 0x00: public, 0x01: random
+		ScanningFilterPolicy: 0x00,   // 0x00: accept all, 0x01: ignore non-white-listed
+		ScanningPHYs:         0x05,   // 0x01: Scan on the LE 1M PHY, 0x04: Scan on the LE Coded PHY
+		ScanType1M:           0x01,   // 0x00: passive scan, 0x01: active scan
+		ScanInterval1M:       0x0064, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanWindow1M:         0x0032, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanTypeCoded:        0x01,   // 0x00: passive scan, 0x01: active scan (for Coded PHY)
+		ScanIntervalCoded:    0x0BB8, // N * 0.625 msec, scan interval for Coded PHY
+		ScanWindowCoded:      0x0032, // N * 0.625 msec, scan window for Coded PHY
+	}
+
+	p.extendedScanParams = cmd.LESetExtendedScanParameters{
+		OwnAddressType:       0x00,   // 0x00: public, 0x01: random
+		ScanningFilterPolicy: 0x00,   // 0x00: accept all, 0x01: ignore non-white-listed
+		ScanningPHYs:         0x05,   // 0x01: Scan on the LE 1M PHY, 0x04: Scan on the LE Coded PHY
+		ScanType1M:           0x01,   // 0x00: passive scan, 0x01: active scan
+		ScanInterval1M:       0x0064, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanWindow1M:         0x0032, // 0x0004 - 0x4000; N * 0.625 msec (2.5 ms)
+		ScanTypeCoded:        0x01,   // 0x00: passive scan, 0x01: active scan (for Coded PHY)
+		ScanIntervalCoded:    0x0BB8, // N * 0.625 msec, scan interval for Coded PHY
+		ScanWindowCoded:      0x0032, // N * 0.625 msec, scan window for Coded PHY
+	}
+
+	p.leSetDefaultPHY = cmd.LESetDefaultPHY{
+		AllPHYs: 0x00, // 0x00: No preference, use all PHYs
+		TXPHYs:  0x07, // 0x01: LE 1M, 0x02: LE 2M, 0x04: LE Coded (0x07 to use all PHYs)
+		RXPHYs:  0x07, // 0x01: LE 1M, 0x02: LE 2M, 0x04: LE Coded (uses all PHYs at 0x07)
 	}
 }

--- a/linux/hci/params.go
+++ b/linux/hci/params.go
@@ -60,7 +60,7 @@ func (p *params) init() {
 	}
 }
 
-func (p *params) initForBLE5() {
+func (p *params) initForAdvertisingExtensions() {
 	p.extendedScanParams = cmd.LESetExtendedScanParameters{
 		OwnAddressType:       0x00,   // 0x00: public, 0x01: random
 		ScanningFilterPolicy: 0x00,   // 0x00: accept all, 0x01: ignore non-white-listed

--- a/linux/tools/codegen/Makefile
+++ b/linux/tools/codegen/Makefile
@@ -1,9 +1,8 @@
-signal_out="../../l2cap/signal_gen.go"
 cmd_out="../../hci/cmd/cmd_gen.go"
 evt_out="../../hci/evt/evt_gen.go"
 att_out="../../att/att_gen.go"
 
-targets := signal cmd evt att
+targets := cmd evt att
 
 all: ${targets}
 

--- a/linux/tools/codegen/cmd.json
+++ b/linux/tools/codegen/cmd.json
@@ -1241,6 +1241,98 @@
                         "Events": [
                                 "Command Complete"
                         ]
+                },
+                {
+                        "Name": "LE Set Extended Scan Parameters",
+                        "Spec": "Vol 4, Part E, 7.8.64",
+                        "OGF": "0x08",
+                        "OCF": "0x0041",
+                        "Len": 13,
+                        "Param": [
+                                { "Own_Address_Type": "uint8" },
+                                { "Scanning_Filter_Policy": "uint8" },
+                                { "Scanning_PHYs": "uint8" },
+                                { "Scan_Type_1M": "uint8" },
+                                { "Scan_Interval_1M": "uint16" },
+                                { "Scan_Window_1M": "uint16" },
+                                { "Scan_Type_Coded": "uint8" },
+                                { "Scan_Interval_Coded": "uint16" },
+                                { "Scan_Window_Coded": "uint16" }
+                        ],
+                        "Return": [
+                                { "Status": "uint8" }
+                        ],
+                        "Events": [
+                                "Command Complete"
+                        ]
+                },
+                {
+                        "Name": "LE Set Extended Scan Enable",
+                        "Spec": "Vol 4, Part E, 7.8.65",
+                        "OGF": "0x08",
+                        "OCF": "0x0042",
+                        "Len": 6,
+                        "Param": [
+                                { "Enable": "uint8" },
+                                { "Filter_Duplicates": "uint8" },
+                                { "Duration": "uint16" },
+                                { "Period": "uint16" }
+                        ],
+                        "Return": [
+                                { "Status": "uint8" }
+                        ],
+                        "Events": [
+                                "Command Complete",
+                                "LE Extended Advertising Report",
+                                "LE Scan Timeout"
+                        ]
+                },
+                {
+                        "Name": "LE Set Default PHY",
+                        "Spec": "Vol 4, Part E, 7.8.48",
+                        "OGF": "0x08",
+                        "OCF": "0x0031",
+                        "Len": 3,
+                        "Param": [
+                                { "All_PHYs": "uint8" },
+                                { "TX_PHYs": "uint8" },
+                                { "RX_PHYs": "uint8" }
+                        ],
+                        "Return": [],
+                        "Events": [
+                                "Command Status",
+                                "LE PHY Update Complete"
+                        ]
+                },
+                {
+                        "Name": "LE Set Extended Advertising Parameters",
+                        "Spec": "Vol 4, Part E, 7.8.53",
+                        "OGF": "0x08",
+                        "OCF": "0x0036",
+                        "Len": 25,
+                        "Param": [
+                                { "Advertising_Handle": "uint8" },
+                                { "Advertising_Event_Properties": "uint16" },
+                                { "Primary_Advertising_Interval_Min": "[3]byte" },
+                                { "Primary_Advertising_Interval_Max": "[3]byte" },
+                                { "Primary_Advertising_Channel_Map": "uint8" },
+                                { "Own_Address_Type": "uint8" },
+                                { "Peer_Address_Type": "uint8" },
+                                { "Peer_Address": "[6]byte" },
+                                { "Advertising_Filter_Policy": "uint8" },
+                                { "Advertising_TX_Power": "int8" },
+                                { "Primary_Advertising_PHY": "uint8" },
+                                { "Secondary_Advertising_Max_Skip": "uint8" },
+                                { "Secondary_Advertising_PHY": "uint8" },
+                                { "Advertising_SID": "uint8" },
+                                { "Scan_Request_Notification_Enable": "uint8" }
+                        ],
+                        "Return": [
+                                { "Status": "uint8" }
+                        ],
+                        "Events": [
+                                "Command Complete"
+                        ]
                 }
         ]
 }

--- a/linux/tools/codegen/evt.json
+++ b/linux/tools/codegen/evt.json
@@ -322,6 +322,30 @@
                                 }
                         ],
                         "DefaultUnmarshaller": true
+                },
+                {
+                        "Name": "LE Extended Advertising Report",
+                        "Spec": "Vol 4, Part E, 7.7.65.13",
+                        "Code": "0x3E",
+                        "SubCode": "0x0D",
+                        "Param": [
+                                { "Subevent_Code": "uint8" },
+                                { "Num_Reports": "uint8" },
+                                { "Event_Type": "[]uint16" },
+                                { "Address_Type": "[]uint8" },
+                                { "Address": "[][6]byte" },
+                                { "Primary_PHY": "[]uint8" },
+                                { "Secondary_PHY": "[]uint8" },
+                                { "Advertising_SID": "[]uint8" },
+                                { "TX_Power": "[]int8" },
+                                { "RSSI": "[]int8" },
+                                { "Periodic_Advertising_Interval": "[]uint16" },
+                                { "Direct_Address_Type": "[]uint8" },
+                                { "Direct_Address": "[][6]byte" },
+                                { "Data_Length": "[]uint8" },
+                                { "Data": "[][]byte" }
+                        ],
+                        "DefaultUnmarshaller": false
                 }
         ]
 }


### PR DESCRIPTION
The following HCI commands are now supported to receive `LE Extended Advertising Reports`.

- LE Set Extended Scan Parameters(Vol 4, Part E, 7.8.64)
- LE Set Extended Scan Enable(Vol 4, Part E, 7.8.65)
- LE Set Default PHY(Vol 4, Part E, 7.8.48)
- LE Set Extended Advertising Parameters(Vol 4, Part E, 7.8.53)
- LE Extended Advertising Report(Vol 4, Part E, 7.7.65.13)