### PR TITLE
Fix parsing issue with zero-padded advertisement data

### DIFF
--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -174,6 +174,10 @@ func (p *Packet) Field(typ byte) []byte {
 			return nil
 		}
 		l, t := b[0], b[1]
+		if l == 0 && t == 0 {
+			b = b[2:]
+			continue
+		}
 		if int(l) < 1 || len(b) < int(1+l) {
 			return nil
 		}


### PR DESCRIPTION
Not sure if this is the correct approach here but it solves the issue I have with a device that for some reason adds padding to its advertisement data: `020106030201a20c1601a200894198a19be587da0000000000000000`.
On linux, the advertisement data is concatenated with the scan response to build the packet and when I try to get a field which is in the scan response portion, it will return nil because we exit early `if int(l) < 1`