### PR TITLE
gatt: Prevent Connect from hanging

### DIFF
--- a/gatt.go
+++ b/gatt.go
@@ -142,6 +142,10 @@ func Connect(ctx context.Context, f AdvFilter) (Client, error) {
 		if err != context.Canceled {
 			return nil, errors.Wrap(err, "can't scan")
 		}
+		// If the parent context was cancelled, Dial below would hang.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 	}
 
 	cln, err := Dial(ctx, (<-ch).Addr())


### PR DESCRIPTION
Also checks the parent context, especially whether it was originally cancelled. Without Connect would block on Dial.

ctx2 in Connect is done once AdvFilter in Scan has selected something. However, meanwhile the parent context could have been then one that got cancelled, for example because the entire program is done.